### PR TITLE
Removed unused dependency `cli-truncate`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "dmg-license",
 			"version": "1.0.9",
 			"license": "MIT",
 			"os": [
@@ -14,7 +15,6 @@
 				"@types/plist": "^3.0.1",
 				"@types/verror": "^1.10.3",
 				"ajv": "^6.10.0",
-				"cli-truncate": "^1.1.0",
 				"crc": "^3.8.0",
 				"iconv-corefoundation": "^1.1.6",
 				"plist": "^3.0.1",
@@ -564,7 +564,6 @@
 			"dependencies": {
 				"anymatch": "~3.1.1",
 				"braces": "~3.0.2",
-				"fsevents": "~2.1.1",
 				"glob-parent": "~5.1.0",
 				"is-binary-path": "~2.1.0",
 				"is-glob": "~4.0.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
 		"@types/plist": "^3.0.1",
 		"@types/verror": "^1.10.3",
 		"ajv": "^6.10.0",
-		"cli-truncate": "^1.1.0",
 		"crc": "^3.8.0",
 		"iconv-corefoundation": "^1.1.6",
 		"plist": "^3.0.1",


### PR DESCRIPTION
As far as I see this dependency is not used, so we could remove it.